### PR TITLE
Panoptic Metrics Bugfix: correctly ignoring void segments

### DIFF
--- a/src/panoptic/metrics.py
+++ b/src/panoptic/metrics.py
@@ -70,7 +70,6 @@ class PanopticMeter:
                                 / (void_inst_area + pred_inst_area - inter).float()
                             )
                             if iou > self.iou_threshold:
-                                nf+=1
                                 instance_pred[batch_idx][
                                     instance_pred[batch_idx] == pred_inst_id
                                 ] = 0

--- a/src/panoptic/metrics.py
+++ b/src/panoptic/metrics.py
@@ -52,13 +52,17 @@ class PanopticMeter:
             for batch_idx, void_mask in enumerate(void_masks):
                 if void_mask.any():
                     for void_inst_id, void_inst_area in zip(
-                        *torch.unique(void_mask, return_counts=True)
+                        *torch.unique(instance_true[batch_idx]*void_mask, return_counts=True)
                     ):
+                        if void_inst_id == 0:
+                            continue
                         for pred_inst_id, pred_inst_area in zip(
                             *torch.unique(instance_pred[batch_idx], return_counts=True)
                         ):
+                            if pred_inst_id == 0:
+                                continue
                             inter = (
-                                (void_mask == void_inst_id)
+                                (instance_true[batch_idx] == void_inst_id)
                                 * (instance_pred[batch_idx] == pred_inst_id)
                             ).sum()
                             iou = (
@@ -66,6 +70,7 @@ class PanopticMeter:
                                 / (void_inst_area + pred_inst_area - inter).float()
                             )
                             if iou > self.iou_threshold:
+                                nf+=1
                                 instance_pred[batch_idx][
                                     instance_pred[batch_idx] == pred_inst_id
                                 ] = 0


### PR DESCRIPTION
Fix for issue #11 

### Problem
Void instances where not correctly matched to predicted instances. Predicted instances matched with void instances were counted as False Positives instead of being ignored. This results in an artificial decrease of the Recognition Quality. 

### Fix 
Iterate over the correct tensor in l.55 of `src/panoptic/metrics.py`.

### Impact
- The metrics reported in the original paper are impacted by this error. I re-runed the evaluation of the different methods of the paper. Across methods, the bug fix entails a ~2 point increase of Panoptic Quality.  The results will be updated in a new Arxiv version. 
- The panoptic metrics are not involved in the training loss so this bug does not affect training procedure. Models that were trained with the previous implementation just need to be re-evaluated with the corrected metrics. 
